### PR TITLE
declared unicode encoding

### DIFF
--- a/fusee-launcher.py
+++ b/fusee-launcher.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# coding: utf-8 -*-
 #
 # fusée gelée
 #


### PR DESCRIPTION
I'm American and every time I would execute the script it would crash, complaining of foreign characters since it's using ASCII encoding and not Unicode, explicitly declaring this resolves the issue.