### PR TITLE
gitignore: ignore fusee.bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/fusee.bin


### PR DESCRIPTION
Allows people to use modchipd.sh without git telling them they have unstaged changes.